### PR TITLE
Check that file exist in saved_file_to_grid.

### DIFF
--- a/src/FerriteGmsh.jl
+++ b/src/FerriteGmsh.jl
@@ -151,6 +151,13 @@ function tocellsets(dim::Int, global_elementtags::Vector{Int})
 end
 
 function saved_file_to_grid(filename::String; domain="")
+    # Check that file exists since Gmsh assumes we want to start a new model
+    # if passing a non-existing path. In this function we need the model to exist.
+    if !isfile(filename)
+        # This is the error that is thrown by open("non-existing"),
+        # error code 2 is "no such file or directory".
+        throw(SystemError("opening file $(repr(filename))", 2))
+    end
     gmsh.initialize()
     gmsh.open(filename)
     fileextension = filename[findlast(isequal('.'), filename):end]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,3 +5,5 @@ using Ferrite
 include("test_jac.jl")
 include("test_mixed_mesh.jl")
 include("test_multiple_entities_group.jl")
+
+@test_throws SystemError saved_file_to_grid("this-file-does-not-exist.msh")


### PR DESCRIPTION
Without this you get this cryptic error:
```
julia> saved_file_to_grid("nope.msh")
ERROR: ArgumentError: reducing over an empty collection is not allowed
```