### PR TITLE
Throw error if no elements found in the model

### DIFF
--- a/src/FerriteGmsh.jl
+++ b/src/FerriteGmsh.jl
@@ -73,6 +73,9 @@ end
 
 function toelements(dim::Int)
     elementtypes, elementtags, nodetags = gmsh.model.mesh.getElements(dim, -1)
+    if isempty(elementtypes)
+        error("could not find any elements with dimension $dim")
+    end
     nodetags_all = convert(Vector{Vector{Int64}}, nodetags)
     if length(elementtypes) == 1
         elementname, _, _, _, _, _ = gmsh.model.mesh.getElementProperties(elementtypes[1])


### PR DESCRIPTION
If there are no elements found in the model a very non-descriptive error is thrown. This can happen if you e.g. have a D-dimensional mesh, and add some physical groups for D-1 dimension, but none for D.