### PR TITLE
Add wrapper around gmsh.initialize

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,9 +5,7 @@ version = "0.1.0"
 
 [deps]
 Ferrite = "c061ca5d-56c9-439f-9c0e-210fe06d3992"
-Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 gmsh_jll = "630162c2-fc9b-58b3-9910-8442a8a132e6"
 
 [compat]
 Ferrite = "0.3"
-Reexport = "1"

--- a/src/FerriteGmsh.jl
+++ b/src/FerriteGmsh.jl
@@ -1,10 +1,9 @@
 module FerriteGmsh
 using Ferrite
-using Reexport
 
 import gmsh_jll
 include(gmsh_jll.gmsh_api)
-@reexport import .gmsh
+import .gmsh
 
 const gmshtoferritecell = Dict("Line 2" => Line,
                               "Line 3" => QuadraticLine,


### PR DESCRIPTION
This wrapper checks whether gmsh is already initialized before calling
gmsh.initialize again. In addition, a Julia exit hook is added which
calls gmsh.finalize().

Also remove usage and dependency on Reexport.jl.