### PR TITLE
Allow Ferrite v0.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,14 @@
 name = "FerriteGmsh"
 uuid = "4f95f4f8-b27c-4ae5-9a39-ea55e634e36b"
 authors = ["Maximilian Köhler <maximilian.koehler@ruhr-uni-bochum.de>"]
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 Ferrite = "c061ca5d-56c9-439f-9c0e-210fe06d3992"
 Gmsh = "705231aa-382f-11e9-3f0c-b7cb4346fdeb"
 
 [compat]
-Ferrite = "0.3"
+Ferrite = "0.3,0.4"
 Gmsh = "0.2.1"
 julia = "1.6"
 


### PR DESCRIPTION
Edit: Isn't required yet, but leaving open as it should be done when Ferrite v0.4 is released...

~To pass tests after Ferrite.jl is bumped to 0.4, this must be released (see https://github.com/Ferrite-FEM/Ferrite.jl/pull/668) Closes #27~