### PR TITLE
function barrier to speedup tofacesets

### DIFF
--- a/src/FerriteGmsh.jl
+++ b/src/FerriteGmsh.jl
@@ -112,18 +112,23 @@ function toboundary(dim::Int)
     return boundarydict
 end
 
+function _add_to_facesettuple!(facesettuple::Set{FaceIndex}, boundaryface::Tuple, faces)
+    for (eleidx, elefaces) in enumerate(faces)
+        if any(issubset.(elefaces, (boundaryface,)))
+            localface = findfirst(x -> issubset(x,boundaryface), elefaces) 
+            push!(facesettuple, FaceIndex(eleidx, localface))
+        end
+    end
+    return facesettuple
+end
+
 function tofacesets(boundarydict::Dict{String,Vector}, elements::Vector{<:Ferrite.AbstractCell})
     faces = Ferrite.faces.(elements)
     facesets = Dict{String,Set{FaceIndex}}()
     for (boundaryname, boundaryfaces) in boundarydict
         facesettuple = Set{FaceIndex}()
         for boundaryface in boundaryfaces
-            for (eleidx, elefaces) in enumerate(faces)
-                if any(issubset.(elefaces, (boundaryface,)))
-                    localface = findfirst(x -> issubset(x,boundaryface), elefaces) 
-                    push!(facesettuple, FaceIndex(eleidx, localface))
-                end
-            end
+            _add_to_facesettuple!(facesettuple, boundaryface, faces)
         end
         facesets[boundaryname] = facesettuple
     end


### PR DESCRIPTION
Fixes https://github.com/Ferrite-FEM/Ferrite.jl/issues/770 (friday procrastination)

Test script master: 45.837502 seconds (758.80 M allocations: 58.793 GiB, 11.57% gc time)
Test script PR: 1.159389 seconds (313.52 k allocations: 20.954 MiB, 1.54% gc time)

<details> 
<summary> Test script </summary>

```julia
using Gmsh
using FerriteGmsh

function setup_grid(hR, Z, r)
    gmsh.initialize()
    gmsh.model.add("mesh")

    gmsh.model.occ.addBox(
        -0.5, -0.5, 0.0-hR,
        1., 1., Z,   
        1)
    gmsh.model.occ.addCone(
        0., 0., 0.0-hR, 
        0.,0.,hR,
        r,0.,
        2)
    gmsh.model.occ.cut([(3,1)], [(3,2)], 3)
   
    gmsh.model.occ.synchronize()

    gmsh.model.addPhysicalGroup(3, [3], -1, "sample")
    gmsh.model.addPhysicalGroup(2, [1], -1, "leftX")
    gmsh.model.addPhysicalGroup(2, [2], -1, "leftY")
    gmsh.model.addPhysicalGroup(2, [3], -1, "topZ")
    gmsh.model.addPhysicalGroup(2, [4], -1, "rightY")
    gmsh.model.addPhysicalGroup(2, [5,7], -1, "bottomZ")
    gmsh.model.addPhysicalGroup(2, [6], -1, "rightX")

    gmsh.model.mesh.setSizeCallback((dim, tag, x, y, z, lc) -> 0.07)
    gmsh.model.mesh.generate(3)
    gmsh.write("mesh.msh")
    gmsh.finalize()

    grid = togrid("mesh.msh")

    return grid
end

@time setup_grid(1, 2, 0.4)
```
</details>