### PR TITLE
Support new Ferrite defintiions with facets

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ domaincellset = cellsets["Domain"]
 elements = elements[collect(domaincellset)]
 
 boundarydict = toboundary(facedim)
-facesets = tofacesets(boundarydict, elements)
+facesets = tofacetsets(boundarydict, elements)
 gmsh.finalize()
 
 Grid(elements, nodes, facesets=facesets, cellsets=cellsets)

--- a/src/FerriteGmsh.jl
+++ b/src/FerriteGmsh.jl
@@ -118,8 +118,8 @@ function toboundary(dim::Int)
     return boundarydict
 end
 
-function _add_to_facetsettuple!(facesettuple::Set{FacetIndex}, boundaryface::Tuple, facets)
-    for (eleidx, elefaces) in enumerate(facets)
+function _add_to_facetsettuple!(facesettuple::Set{FacetIndex}, boundaryface::Tuple, element_facets)
+    for (eleidx, elefaces) in enumerate(element_facets)
         if any(issubset.(elefaces, (boundaryface,)))
             localface = findfirst(x -> issubset(x,boundaryface), elefaces) 
             push!(facesettuple, FacetIndex(eleidx, localface))

--- a/src/FerriteGmsh.jl
+++ b/src/FerriteGmsh.jl
@@ -118,14 +118,14 @@ function toboundary(dim::Int)
     return boundarydict
 end
 
-function _add_to_facetsettuple!(facesettuple::Set{FacetIndex}, boundaryface::Tuple, element_facets)
-    for (eleidx, elefaces) in enumerate(element_facets)
-        if any(issubset.(elefaces, (boundaryface,)))
-            localface = findfirst(x -> issubset(x,boundaryface), elefaces) 
-            push!(facesettuple, FacetIndex(eleidx, localface))
+function _add_to_facetsettuple!(facetsettuple::Set{FacetIndex}, boundaryface::Tuple, element_facets)
+    for (eleidx, elefacets) in enumerate(element_facets)
+        if any(issubset.(elefacets, (boundaryfacet,)))
+            localfacet = findfirst(x -> issubset(x,boundaryfacet), elefacets) 
+            push!(facetsettuple, FacetIndex(eleidx, localfacet))
         end
     end
-    return facesettuple
+    return facetsettuple
 end
 
 function tofacetsets(boundarydict::Dict{String,Vector}, elements::Vector{<:Ferrite.AbstractCell})

--- a/src/FerriteGmsh.jl
+++ b/src/FerriteGmsh.jl
@@ -118,7 +118,7 @@ function toboundary(dim::Int)
     return boundarydict
 end
 
-function _add_to_facetsettuple!(facetsettuple::Set{FacetIndex}, boundaryface::Tuple, element_facets)
+function _add_to_facetsettuple!(facetsettuple::Set{FacetIndex}, boundaryfacet::Tuple, element_facets)
     for (eleidx, elefacets) in enumerate(element_facets)
         if any(issubset.(elefacets, (boundaryfacet,)))
             localfacet = findfirst(x -> issubset(x,boundaryfacet), elefacets) 

--- a/test/devtests.jl
+++ b/test/devtests.jl
@@ -24,7 +24,7 @@ gmsh.model.mesh.generate(2)
 nodes = tonodes()
 elements, gmsh_eleidx = toelements(2)
 boundarydict = toboundary(1)
-faceset = tofacesets(boundarydict, elements)
+faceset = tofacetsets(boundarydict, elements)
 
 grid = Grid(elements,nodes,facesets=faceset)
 

--- a/test/test_mixed_mesh.jl
+++ b/test/test_mixed_mesh.jl
@@ -51,7 +51,7 @@
     nodes = tonodes()
     elements, gmsh_eleidx = toelements(2)
     boundarydict = toboundary(1)
-    facesets = tofacesets(boundarydict,elements)
+    facesets = tofacetsets(boundarydict,elements)
     cellsets = tocellsets(2,gmsh_eleidx)
     grid = Grid(elements,nodes,facesets=facesets,cellsets=cellsets)
     @test grid.facesets["bottom"] == Set([FaceIndex(15,1),FaceIndex(17,1)])


### PR DESCRIPTION
With this PR, FerriteGmsh should work for both 
Ferrite 0.3 and Ferrite#master (soon 1.0) (tested building Ferrite docs locally with this branch). 

To have naming consistent, I've deprecated `tofacesets` in favor of `tofacetsets`. 

If that is not desired, could wait with this and just forward without deprecation to `tofacesets`, which gives a `Set{FaceIndex}` prior to Ferrite defining facets, and `Set{FacetIndex}` after, so that it is not breaking. 

A release will be required to allow us to remove the current workarounds in the Ferrite docs. 