### PR TITLE
function barriers

### DIFF
--- a/src/FerriteGmsh.jl
+++ b/src/FerriteGmsh.jl
@@ -67,7 +67,7 @@ function tonodes()
     dim = Int64(gmsh.model.getDimension()) # Int64 otherwise julia crashes
     return _create_nodes(Val(dim), nodes)
 end
-function _create_nodes(::Val{dim}, nodes) where Dim
+function _create_nodes(::Val{dim}, nodes) where dim
     return [Node(Vec{dim}(nodes[i:i + (dim - 1)])) for i in 1:3:length(nodes)]
 end
 

--- a/src/FerriteGmsh.jl
+++ b/src/FerriteGmsh.jl
@@ -67,8 +67,8 @@ function tonodes()
     dim = Int64(gmsh.model.getDimension()) # Int64 otherwise julia crashes
     return _create_nodes(Val(dim), nodes)
 end
-function _create_nodes(::Val{Dim}, nodes) where Dim
-    return [Node(Vec{Dim}(nodes[i:i + (Dim - 1)])) for i in 1:3:length(nodes)]
+function _create_nodes(::Val{dim}, nodes) where Dim
+    return [Node(Vec{dim}(nodes[i:i + (dim - 1)])) for i in 1:3:length(nodes)]
 end
 
 function toelements(dim::Int)
@@ -96,7 +96,7 @@ function toelements(dim::Int)
     return elements, reduce(vcat,convert(Vector{Vector{Int64}}, elementtags))
 end
 
-function _create_elements_gmsh(::Type{CT}, ::Val{N}, nodetags) where {CT <: Ferrite.AbstractCell, N, T}
+function _create_elements_gmsh(::Type{CT}, ::Val{N}, nodetags) where {CT <: Ferrite.AbstractCell, N}
     return [CT(NTuple{N, Int}(nodetags[i:i + (N - 1)])) for i in 1:N:length(nodetags)]
 end
 


### PR DESCRIPTION
Got inspired when seeing #39, after that is fixed, these were the main sources of time spent in the translation. 

```julia
using Gmsh: Gmsh, gmsh
using FerriteGmsh
using Downloads: download

function get_msh()
    logo_mesh = "logo.geo"
    asset_url = "https://raw.githubusercontent.com/Ferrite-FEM/Ferrite.jl/gh-pages/assets/"
    isfile(logo_mesh) || download(string(asset_url, logo_mesh), logo_mesh)
    Gmsh.initialize()
    gmsh.open("logo.geo")
    gmsh.option.setNumber("Mesh.MeshSizeMax", 0.01)
    gmsh.model.mesh.generate(2)
    gmsh.write("logo.msh")
    Gmsh.finalize()
end

function load_msh()
    return togrid("logo.msh")
end
```

`@time load_msh()` goes from `0.250281 seconds (264.77 k allocations: 17.653 MiB)` to `0.190106 seconds (36.86 k allocations: 10.099 MiB)` without #39 (with #39, the relative change is more significant and almost all time is spent in `gmsh.open`). 